### PR TITLE
fix: tiny preprocessing bug in complete sc analysis

### DIFF
--- a/single_cell_analysis_complete_class.ipynb
+++ b/single_cell_analysis_complete_class.ipynb
@@ -3130,7 +3130,7 @@
     "    \n",
     "    sc.pp.filter_cells(adata, min_genes=200) #get rid of cells with fewer than 200 genes\n",
     "    #sc.pp.filter_genes(adata, min_cells=3) #get rid of genes that are found in fewer than 3 cells\n",
-    "    adata.var['mt'] = adata.var_names.str.startswith('mt-')  # annotate the group of mitochondrial genes as 'mt'\n",
+    "    adata.var['mt'] = adata.var_names.str.startswith('MT-')  # annotate the group of mitochondrial genes as 'mt'\n",
     "    adata.var['ribo'] = adata.var_names.isin(ribo_genes[0].values)\n",
     "    sc.pp.calculate_qc_metrics(adata, qc_vars=['mt', 'ribo'], percent_top=None, log1p=False, inplace=True)\n",
     "    upper_lim = np.quantile(adata.obs.n_genes_by_counts.values, .98)\n",


### PR DESCRIPTION
Hello, I loved the tutorial!
I found this small bug when playing around with it:

in the pp() when annotating mitochondrial genes:
lowercase startswith("mt-") won't catch anything in this data
so I just changed it to startswith("MT-")

I'd understand if this isn't a PR worthy change, but I found this confusing
when following the tutorial so I thought I would propose a change.